### PR TITLE
Allow to let routes decide if they can assemble

### DIFF
--- a/src/Dash/Router/Http/Route/AssembleableInterface.php
+++ b/src/Dash/Router/Http/Route/AssembleableInterface.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace Dash\Router\Http\Route;
+
+/**
+ * Interface that can be implemented by custom routes, so that routes can decide themselves if they
+ * can be assembled
+ */
+interface AssembleableInterface
+{
+    /**
+     * Can the route assemble using the given params and options?
+     *
+     * @param  array $params
+     * @param  array $options
+     * @return bool
+     */
+    public function canAssemble(array $params, array $options);
+}

--- a/src/Dash/Router/Http/Router.php
+++ b/src/Dash/Router/Http/Router.php
@@ -130,7 +130,9 @@ class Router implements RouterInterface
             $assemblyResult    = $assembleableRoute->assemble($params);
 
             if (null === $assembleableRoute) {
-                throw new Exception\RuntimeException('No route name was supplied or no routes could assemble');
+                throw new Exception\RuntimeException(
+                    'No route name was supplied or no routes could assemble with the given params and options'
+                );
             }
         } else {
             $nameParts  = explode('/', $options['name'], 2);


### PR DESCRIPTION
ping @ocramius

Hi,

This PR tries to solve an issue I have with ZfrRest. With ZF2 router and current Dash, the only way to assemble a route is to know its name:

```php
$path = $router->assemble([], ['name' => 'users']); // prints /users
```

However, routes are not always that simple. For instance, ZfrRest routes automatically traverses a hierarchy and can generate URI far beyond that what was defined in the "route" option. For instance, if a user has an association called "tweets", if you only define the "users" route with a "/users" path, ZfrRest may generate a lot of different URI: /users, /users/1, /users/2/tweets...

Because those routes are not actually defined in the config, there is currently no way to actually generate those URL without ugly hacks. What I'd like is actually letting my routes to decide if they can assemble something (based on parameters, options...). I could, for instance, use the router as follow:

```php
$path = $router->assemble(['template' => '/users/{user_id}/tweets']);
```

The route could then decide to accept or reject the option. If the route returns true to "canAssemble", then the router let the given route to assemble.