### PR TITLE
Add semi-automatic response-modfication

### DIFF
--- a/src/MatchResult/MatchResultInterface.php
+++ b/src/MatchResult/MatchResultInterface.php
@@ -9,6 +9,8 @@
 
 namespace Dash\MatchResult;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Interface describing match results returned by routers.
  */
@@ -20,4 +22,12 @@ interface MatchResultInterface
      * @return bool
      */
     public function isSuccess();
+
+    /**
+     * Modifies the response to properly indicate the kind of failure.
+     *
+     * @param  ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function modifyResponse(ResponseInterface $response);
 }

--- a/src/MatchResult/MethodNotAllowed.php
+++ b/src/MatchResult/MethodNotAllowed.php
@@ -9,6 +9,8 @@
 
 namespace Dash\MatchResult;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * HTTP specific match result if a method is not allowed by a route.
  */
@@ -25,6 +27,13 @@ class MethodNotAllowed extends AbstractFailedMatch
     public function __construct(array $allowedMethods)
     {
         $this->allowedMethods = $allowedMethods;
+    }
+
+    public function modifyResponse(ResponseInterface $response)
+    {
+        return $response
+            ->withStatus(405)
+            ->withHeader('Allow', implode(', ', $this->allowedMethods));
     }
 
     /**

--- a/src/MatchResult/SchemeNotAllowed.php
+++ b/src/MatchResult/SchemeNotAllowed.php
@@ -9,6 +9,7 @@
 
 namespace Dash\MatchResult;
 
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -27,6 +28,13 @@ class SchemeNotAllowed extends AbstractFailedMatch
     public function __construct(UriInterface $allowedUri)
     {
         $this->allowedUri = $allowedUri;
+    }
+
+    public function modifyResponse(ResponseInterface $response)
+    {
+        return $response
+            ->withStatus(301)
+            ->withHeader('Location', (string) $this->allowedUri);
     }
 
     /**

--- a/src/MatchResult/SuccessfulMatch.php
+++ b/src/MatchResult/SuccessfulMatch.php
@@ -10,6 +10,7 @@
 namespace Dash\MatchResult;
 
 use Dash\Parser\ParseResult;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Generic successful match result.
@@ -122,5 +123,10 @@ class SuccessfulMatch implements MatchResultInterface
     final public function isSuccess()
     {
         return true;
+    }
+
+    public function modifyResponse(ResponseInterface $response)
+    {
+        return $response;
     }
 }

--- a/src/MatchResult/UnsuccessfulMatch.php
+++ b/src/MatchResult/UnsuccessfulMatch.php
@@ -9,9 +9,15 @@
 
 namespace Dash\MatchResult;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Unspecific match result when the router could not match the request.
  */
 class UnsuccessfulMatch extends AbstractFailedMatch
 {
+    public function modifyResponse(ResponseInterface $response)
+    {
+        return $response->withStatus(404);
+    }
 }

--- a/test/MatchResult/MethodNotAllowedTest.php
+++ b/test/MatchResult/MethodNotAllowedTest.php
@@ -10,6 +10,7 @@
 namespace DashTest\MatchResult;
 
 use Dash\MatchResult\MethodNotAllowed;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -32,5 +33,13 @@ class MethodNotAllowedTest extends TestCase
         $result = new MethodNotAllowed(['GET', 'PUT']);
         $result->merge(new MethodNotAllowed(['POST', 'GET']));
         $this->assertEquals(['GET', 'PUT', 'POST'], $result->getAllowedMethods());
+    }
+
+    public function testModifyResponse()
+    {
+        $result   = new MethodNotAllowed(['GET', 'PUT']);
+        $response = $result->modifyResponse(new Response());
+        $this->assertSame(405, $response->getStatusCode());
+        $this->assertSame('GET, PUT', $response->getHeaderLine('Allow'));
     }
 }

--- a/test/MatchResult/SchemeNotAllowedTest.php
+++ b/test/MatchResult/SchemeNotAllowedTest.php
@@ -10,6 +10,7 @@
 namespace DashTest\MatchResult;
 
 use Dash\MatchResult\SchemeNotAllowed;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -27,5 +28,13 @@ class SchemeNotAllowedTest extends TestCase
     {
         $uri = new Uri('https://example.com');
         $this->assertSame($uri, (new SchemeNotAllowed($uri))->getAllowedUri());
+    }
+
+    public function testModifyResponse()
+    {
+        $result   = new SchemeNotAllowed(new Uri('https://example.com'));
+        $response = $result->modifyResponse(new Response());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaderLine('Location'));
     }
 }

--- a/test/MatchResult/SuccessfulMatchTest.php
+++ b/test/MatchResult/SuccessfulMatchTest.php
@@ -11,6 +11,7 @@ namespace DashTest\MatchResult;
 
 use Dash\MatchResult\SuccessfulMatch;
 use Dash\Parser\ParseResult;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -73,5 +74,12 @@ class SuccessfulMatchTest extends TestCase
         $otherMatch->prependRouteName('bar');
         $result->merge($otherMatch);
         $this->assertEquals('bar/foo', $result->getRouteName());
+    }
+
+    public function testModifyResponse()
+    {
+        $result   = new SuccessfulMatch();
+        $response = new Response();
+        $this->assertEquals(clone $response, $result->modifyResponse($response));
     }
 }

--- a/test/MatchResult/UnsuccessfulMatchTest.php
+++ b/test/MatchResult/UnsuccessfulMatchTest.php
@@ -10,6 +10,7 @@
 namespace DashTest\MatchResult;
 
 use Dash\MatchResult\UnsuccessfulMatch;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -20,5 +21,11 @@ class UnsuccessfulMatchTest extends TestCase
     public function testIsSuccess()
     {
         $this->assertFalse((new UnsuccessfulMatch())->isSuccess());
+    }
+
+    public function testModifyResponse()
+    {
+        $result = new UnsuccessfulMatch();
+        $this->assertSame(404, $result->modifyResponse(new Response())->getStatusCode());
     }
 }


### PR DESCRIPTION
This PR adds the possibility for match results to modify the response object. Specifically, this has the following use case:

When a response is not successful, it can take care of modifying the response object, instead of leaving the application to handle that job. Currently, the following cases are handled:

- On an unsuccessful match, a 404 status code is injected.
- On a method not allowed case, a 405 status code is injected together with an ```Allow ``` header listing the allowed methods.
- On a scheme not allowed case, a 301 status code is injected together with a ```Location``` header pointing to the same URL but with an HTTPS scheme.

Example usage:

```php
$matchResult = $router->match($request);

if (!$matchResult->isSuccess()) {
    $response = $matchResult->modifyResponse($response);
    // Bubble up the response
}
```