### PR TITLE
Make route name explicit for assembling

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -103,13 +103,9 @@ class Router implements RouterInterface
      *
      * @throws RuntimeException
      */
-    public function assemble(array $params, array $options)
+    public function assemble($routeName, array $params = [], array $options = [])
     {
-        if (!isset($options['name'])) {
-            throw new RuntimeException('No route name was supplied');
-        }
-
-        $nameParts  = explode('/', $options['name'], 2);
+        $nameParts  = explode('/', $routeName, 2);
         $parentName = $nameParts[0];
         $childName  = isset($nameParts[1]) ? $nameParts[1] : null;
 

--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -26,11 +26,12 @@ interface RouterInterface
     public function match(ServerRequestInterface $request);
 
     /**
-     * Assembles a response.
+     * Assembles a URL.
      *
-     * @param  array $params
-     * @param  array $options
+     * @param  string $routeName
+     * @param  array  $params
+     * @param  array  $options
      * @return string
      */
-    public function assemble(array $params, array $options);
+    public function assemble($routeName, array $params = [], array $options = []);
 }

--- a/test/RouterTest.php
+++ b/test/RouterTest.php
@@ -167,14 +167,6 @@ class RouterTest extends TestCase
         $router->match($this->prophesize(ServerRequestInterface::class)->reveal());
     }
 
-    public function testAssembleFailsWithoutRouteName()
-    {
-        $router = new Router($this->buildRouteCollection(), 'http://example.com/foo');
-
-        $this->setExpectedException(RuntimeException::class, 'No route name was supplied');
-        $router->assemble([], []);
-    }
-
     public function testAssemblePassesDownChildName()
     {
         $route = $this->prophesize(RouteInterface::class);
@@ -184,7 +176,7 @@ class RouterTest extends TestCase
             'foo' => $route->reveal(),
         ]), 'http://example.com/foo');
 
-        $router->assemble([], ['name' => 'foo/bar']);
+        $router->assemble('foo/bar');
     }
 
     public function testAssemblePassesNullWithoutFurtherChildren()
@@ -196,7 +188,7 @@ class RouterTest extends TestCase
             'foo' => $route->reveal(),
         ]), 'http://example.com/foo');
 
-        $router->assemble([], ['name' => 'foo']);
+        $router->assemble('foo');
     }
 
     public function testAssembleReturnsCanonicalUriWhenForced()
@@ -208,8 +200,8 @@ class RouterTest extends TestCase
             'foo' => $route->reveal(),
         ]), 'http://example.com/foo');
 
-        $this->assertEquals('http://example.com/foo', $router->assemble([], [
-            'name' => 'foo', 'force_canonical' => true
+        $this->assertEquals('http://example.com/foo', $router->assemble('foo', [], [
+            'force_canonical' => true
         ]));
     }
 
@@ -222,7 +214,7 @@ class RouterTest extends TestCase
             'foo' => $route->reveal(),
         ]), 'http://example.com/foo');
 
-        $this->assertEquals('/foo?foo=bar', $router->assemble([], ['name' => 'foo', 'query' => ['foo' => 'bar']]));
+        $this->assertEquals('/foo?foo=bar', $router->assemble('foo', [], ['query' => ['foo' => 'bar']]));
     }
 
     public function testAssembleFragment()
@@ -234,7 +226,7 @@ class RouterTest extends TestCase
             'foo' => $route->reveal(),
         ]), 'http://example.com/foo');
 
-        $this->assertEquals('/foo#foo', $router->assemble([], ['name' => 'foo', 'fragment' => 'foo']));
+        $this->assertEquals('/foo#foo', $router->assemble('foo', [], ['fragment' => 'foo']));
     }
 
     /**


### PR DESCRIPTION
This was kinda a bad habit we introduced in ZF2, which actually made quite a few things bad to handle, and in the entire time we never saw a router popping up which doesn't work with route names (or, for that matter, any router at all using our interface, people always just wrote custom routes).

Thus, let's make `$routeName` explicit!